### PR TITLE
fix make ps4 bin file too big, elf-loader can not build error.

### DIFF
--- a/make/ps4sdk.mk
+++ b/make/ps4sdk.mk
@@ -97,7 +97,7 @@ Lf ?=
 AssemblerFlags = -m64
 CompilerNoWarningFlags = -Wno-zero-length-array -Wno-format-pedantic
 CompilerFlags = -std=c11 -O3 -Wall -pedantic -m64 -mcmodel=large $(CompilerNoWarningFlags) $(IncludePath) $(Debug)
-LinkerFlags = -O3 -Wall -m64 $(LibraryPath) $(Debug)
+LinkerFlags = -O3 -Wall -m64  -Wl,--build-id=none $(LibraryPath) $(Debug)
 ArchiverFlags = rcs
 
 ###################################


### PR DESCRIPTION
my environment:
Ubuntu 16.04 LTS x86_64
clang 3.8

I build elf-loader with ps4sdk. when buliding elf-loader/ps4/binary/user it will report err :

> cp bin/user bin/user.elf
> objcopy bin/user -O binary bin/user
> ../../../generate/bin/generate Elf bin/user ../../../local/ldr/ldr.js
> Bin bin/user could not be loaded

I found the bin file "user" is too huge.
I keep the elf of the bin file, and read it info : 

> $ readelf -l  ps4/binary/user/bin/user.elf 
> 
> Elf file type is EXEC (Executable file)
> Entry point 0x93a300000
> There are 6 program headers, starting at offset 64
> 
> Program Headers:
>   Type           Offset             VirtAddr           PhysAddr           FileSiz            MemSiz              Flags  Align
>   LOAD           0x0000000000000000 0x0000000000400000 0x0000000000400000                0x00000000000001b4 0x00000000000001b4  R      200000
>   LOAD           0x0000000000100000 0x000000093a300000 0x000000093a300000                 0x000000000000bfc0 0x000000000000bfc0  R E    200000
>   LOAD           0x0000000000200000 0x000000093a400000 0x000000093a400000                 0x0000000000000000 0x00000000000002b0  RW     200000
>   NOTE           0x0000000000000190 0x0000000000400190 0x0000000000400190                 0x0000000000000024 0x0000000000000024  R      4
>   GNU_EH_FRAME   0x000000000010a1e4 0x000000093a30a1e4 0x000000093a30a1e4                 0x000000000000050c 0x000000000000050c  R      4
>   GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000                 0x0000000000000000 0x0000000000000000  RWE    10
> 
>  Section to Segment mapping:
>   Segment Sections...
>    00     .note.gnu.build-id 
>    01     .text .rodata .eh_frame_hdr .eh_frame 
>    02     .bss 
>    03     .note.gnu.build-id 
>    04     .eh_frame_hdr 
>    05     

**.note.gnu.build-id** is added to the section, it base offset is 0x0000000000400000, it make that the bin file is too huge.

so I add options : the -Wl,--build-id=none,  then **.note.gnu.build-id** is disable.
