### PR TITLE
Fixed linking order

### DIFF
--- a/make/trait/kernel_execute.mk
+++ b/make/trait/kernel_execute.mk
@@ -2,7 +2,7 @@
 
 #Link in kernel exploit by default
 #This makes the executable firmware dependent
-Libraries += -lPs4_extension_kernel_execute_dynlib_prepare_dlclose
 Libraries += -lPs4_extension_kernel_call_standard
+Libraries += -lPs4_extension_kernel_execute_dynlib_prepare_dlclose
 
 ###################################


### PR DESCRIPTION
The order of libraries has been changed to fix the error during the compilation of the source files with the sdk.
