### PR TITLE
Feature/externalize stub library build

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -1,20 +1,16 @@
-ifndef Ps4Sdk
-ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
-endif
-ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
-endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
-endif
-endif
+###################################
+
+Ps4Sdk ?= $(CURDIR)/..
 
 target ?= ps4_lib_no_all
 BuildPath := $(Ps4Sdk)/build
 OutPath := $(Ps4Sdk)/lib
 
+###################################
+
 include $(Ps4Sdk)/make/ps4sdk.mk
+
+###################################
 
 define generateCObject
 $(patsubst %,$(BuildPath)/%,$(patsubst %.c,%.o,$(1))): $(1)

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,20 +1,16 @@
-ifndef Ps4Sdk
-ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
-endif
-ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
-endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
-endif
-endif
+###################################
+
+Ps4Sdk ?= $(CURDIR)/..
 
 target ?= ps4_lib_no_all
 BuildPath := $(Ps4Sdk)/build
 OutPath := $(Ps4Sdk)/lib
 
+###################################
+
 include $(Ps4Sdk)/make/ps4sdk.mk
+
+###################################
 
 define generateCObject
 $(patsubst %,$(BuildPath)/%,$(patsubst %.c,%.c.o,$(1))): $(1)

--- a/core/Makefile
+++ b/core/Makefile
@@ -2,73 +2,13 @@
 
 Ps4Sdk ?= $(CURDIR)/..
 
-target := ps4_lib_no_all
+target := ps4_stub_lib
 BuildPath := $(Ps4Sdk)/build
 OutPath := $(Ps4Sdk)/lib
 
 ###################################
 
-ifndef Ps4SdkFlags
-ifdef ps4sdkflags
-Ps4SdkFlags := $(ps4sdkflags)
-endif
-ifdef PS4SDKCFLAGS
-Ps4SdkFlags := $(PS4SDKCFLAGS)
-endif
-endif
-
-###################################
-
 include $(Ps4Sdk)/make/ps4sdk.mk
-
-archive2 = $(Archiver) $(ArchiverFlags)
-
-#dirp = @mkdir -p $(@D)
-#archive := $(Archiver) $(ArchiverFlags)
-
-#generateObject <type> <lib> <module> <symbol>
-define generateObject
-$(BuildPath)/$(strip $(2))/$(strip $(4)).stub.o: stub/$(strip $(1)).stub.c
-ifeq ("$(wildcard $$@)", "")
-	@mkdir -p $$@
-	@rmdir $$@
-endif
-	@$$(compile) -DPS4_STUB_MODULE="$(strip $(3))" -DPS4_STUB_SYMBOL="$(strip $(4))"
-
-endef
-
-#generateLibrary <type> <lib> <module> <symbols> <extobj>
-define generateLibrary
-$(foreach i, $(4), $(call generateObject, $(1), $(2), $(3), $(i)))
-$(OutPath)/$(strip $(2))_stub.a: $(5) $(patsubst %,$(BuildPath)/$(strip $(2))/%.stub.o,$(strip $(4)))
-	$$(dirp)
-	$$(archive)
-all:: $(OutPath)/$(strip $(2))_stub.a
-clean::
-	rm -fR $(BuildPath)/$(strip $(2)) $(OutPath)/$(strip $(2))_stub.a
-
-endef
-
-#generateLibrary <type> <lib> <module> <symbols> <extobj>
-define generateLibraryLarge
-$(foreach i, $(4), $(call generateObject, $(1), $(2), $(3), $(i)))
-$(OutPath)/$(strip $(2))_stub.a: $(5) $(patsubst %,$(BuildPath)/$(strip $(2))/%.stub.o,$(strip $(4)))
-	$$(dirp)
-	find $$(BuildPath)/$$(strip $(2)) -name *.o > /tmp/ps4sdk_$$(strip $(2))_object.tmp
-	xargs $$(archive2) $$(OutPath)/$$(strip $(2))_stub.a < /tmp/ps4sdk_$$(strip $(2))_object.tmp
-	rm -rf /tmp/ps4sdk_$$(strip $(2))_object.tmp
-all:: $(OutPath)/$(strip $(2))_stub.a
-clean::
-	rm -fR $(BuildPath)/$(strip $(2)) $(OutPath)/$(strip $(2))_stub.a
-
-endef
-
-#generateModule <module> <symbols>
-define generateModule
-$(call generateObject, module, $(1), $(1), $(1))
-$(call generateLibrary, function, $(1), $(1), $(2), $(BuildPath)/$(strip $(1))/$(strip $(1)).stub.o)
-
-endef
 
 include $(CURDIR)/stub.mk
 

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -1,21 +1,17 @@
-ifndef Ps4Sdk
-ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
-endif
-ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
-endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
-endif
-endif
+###################################
+
+Ps4Sdk ?= $(CURDIR)/..
 
 target ?= ps4_lib_no_all
 BuildPath := $(Ps4Sdk)/build
 OutPath := $(Ps4Sdk)/lib
 IncludePath := -I$(wildcard */*/include) #FIXME: Need to gen correctly
 
+###################################
+
 include $(Ps4Sdk)/make/ps4sdk.mk
+
+###################################
 
 define generateCObject
 $(patsubst %,$(BuildPath)/%,$(patsubst %.c,%.o,$(1))): $(1)

--- a/make/target/ps4_stub_lib.mk
+++ b/make/target/ps4_stub_lib.mk
@@ -1,0 +1,60 @@
+###################################
+
+include $(MakePath)/trait/freestanding.mk
+include $(MakePath)/trait/ps4.mk
+include $(MakePath)/trait/pic.mk
+
+###################################
+
+CompilerFlags += -I $(Ps4Sdk)/core/include
+
+###################################
+
+archive2 = $(Archiver) $(ArchiverFlags)
+
+#dirp = @mkdir -p $(@D)
+#archive := $(Archiver) $(ArchiverFlags)
+
+#generateObject <type> <lib> <module> <symbol>
+define generateObject
+$(BuildPath)/$(strip $(2))/$(strip $(4)).stub.o: $(Ps4Sdk)/core/stub/$(strip $(1)).stub.c
+ifeq ("$(wildcard $$@)", "")
+	@mkdir -p $$@
+	@rmdir $$@
+endif
+	@$$(compile) -DPS4_STUB_MODULE="$(strip $(3))" -DPS4_STUB_SYMBOL="$(strip $(4))"
+
+endef
+
+#generateLibrary <type> <lib> <module> <symbols> <extobj>
+define generateLibrary
+$(foreach i, $(4), $(call generateObject, $(1), $(2), $(3), $(i)))
+$(OutPath)/$(strip $(2))_stub.a: $(5) $(patsubst %,$(BuildPath)/$(strip $(2))/%.stub.o,$(strip $(4)))
+	$$(dirp)
+	$$(archive)
+all:: $(OutPath)/$(strip $(2))_stub.a
+clean::
+	rm -fR $(BuildPath)/$(strip $(2)) $(OutPath)/$(strip $(2))_stub.a
+
+endef
+
+#generateLibrary <type> <lib> <module> <symbols> <extobj>
+define generateLibraryLarge
+$(foreach i, $(4), $(call generateObject, $(1), $(2), $(3), $(i)))
+$(OutPath)/$(strip $(2))_stub.a: $(5) $(patsubst %,$(BuildPath)/$(strip $(2))/%.stub.o,$(strip $(4)))
+	$$(dirp)
+	find $$(BuildPath)/$$(strip $(2)) -name *.o > /tmp/ps4sdk_$$(strip $(2))_object.tmp
+	xargs $$(archive2) $$(OutPath)/$$(strip $(2))_stub.a < /tmp/ps4sdk_$$(strip $(2))_object.tmp
+	rm -rf /tmp/ps4sdk_$$(strip $(2))_object.tmp
+all:: $(OutPath)/$(strip $(2))_stub.a
+clean::
+	rm -fR $(BuildPath)/$(strip $(2)) $(OutPath)/$(strip $(2))_stub.a
+
+endef
+
+#generateModule <module> <symbols>
+define generateModule
+$(call generateObject, module, $(1), $(1), $(1))
+$(call generateLibrary, function, $(1), $(1), $(2), $(BuildPath)/$(strip $(1))/$(strip $(1)).stub.o)
+
+endef

--- a/make/trait/pic.mk
+++ b/make/trait/pic.mk
@@ -1,5 +1,5 @@
 ###################################
 
-CompilerFlags += $(Ps4SdkFlags) -fPIC
+CompilerFlags += -fPIC
 
 ###################################


### PR DESCRIPTION
This change will allow us to define and maintain libraries in their own repos.

For backward compatibility, this PR will not remove the internally build libs. After the PR is merged, we should version the change and then remove the internal libraries in another PR.

The headers specifically should be kept, as they are in `include/sce` and will not conflict the new way of directly putting them in `/include`. This will allow old code to build until it has been ported.