### PR TITLE
PS4 cmake toolchain

### DIFF
--- a/cmake/PS4.toolchain.cmake
+++ b/cmake/PS4.toolchain.cmake
@@ -1,0 +1,58 @@
+set(triple "x86_64-scei-ps4")
+
+set(CMAKE_C_COMPILER "clang")
+set(CMAKE_CXX_COMPILER "clang++")
+set(CMAKE_C_COMPILER_AR "ar")
+set(CMAKE_LINKER "clang")
+set(CMAKE_ASM_COMPILER "clang")
+set(CMAKE_FIND_ROOT_PATH "$ENV{PS4SDK}")
+set(CMAKE_SYSROOT "$ENV{PS4SDK}/")
+
+# compiler has to be 'forced' to skip cxx compiler test
+# which fails due the crt0.s not being compatible with CXX
+set(CMAKE_CXX_COMPILER_FORCED on)
+set(CMAKE_C_COMPILER_TARGET "${triple}")
+set(CMAKE_CXX_COMPILER_TARGET "${triple}")
+
+# only search for libraries and includes in the PS4SDK directory
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_SKIP_RPATH true)
+
+set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
+set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -Wall -pedantic -m64 -mcmodel=large -nostdlib -nostdinc -ffreestanding -fPIE -fno-builtin -fno-stack-protector -D__PS4__" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -m64 -mcmodel=large -nostdlib -nostdinc -ffreestanding -fPIE -fno-stack-protector -D__PS4__" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-O3 -Wall -m64 -pie -nostartfiles -nostdlib  $ENV{PS4SDK}/crt0.s " CACHE STRING "")
+
+link_directories("$ENV{PS4SDK}/lib")
+
+set(TOOLCHAIN_PS4SDK_LIBS)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_extension_kernel_execute_dynlib_prepare_dlclose Ps4_extension_kernel_call_standard)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_common_kernel Ps4_common_user Ps4_common_generic)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_common_generic)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4LibCInternalAdaptive_stub Ps4LibKernelAdaptive_stub)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS SceLibcInternal_stub kernel_stub)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS ps4Kernel_stub)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_base_stub_resolve_minimal)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_base_kernel_dlsym_standard Ps4_base_kernel_seek_elf_address_standard)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_base_assembler_register_parameter_standard)
+LIST(APPEND TOOLCHAIN_PS4SDK_LIBS Ps4_base_assembler_system_call_rop_0x93a4FFFF8)
+
+
+# this is a work around to avoid duplicate library warning,
+# as the toolchain file can be proccessed multiple times
+# people over cmake IRC suggest I move this to a find module
+# instead of messing with policies as they might be removed in time AKA TODO
+cmake_policy(SET CMP0002 OLD)
+
+add_library(PS4LIBS INTERFACE)
+add_library(PS4::LIBS ALIAS PS4LIBS)
+target_link_libraries(PS4LIBS INTERFACE ${TOOLCHAIN_PS4SDK_LIBS})
+
+add_library(PS4HEADERS INTERFACE)
+add_library(PS4::HEADERS ALIAS PS4HEADERS)
+target_include_directories(PS4HEADERS INTERFACE "$ENV{PS4SDK}/include/c++/v1/" "$ENV{PS4SDK}/include/" "$ENV{PS4SDK}/include/sce/" "$ENV{PS4SDK}/include/ps4/")
+include_directories("$ENV{PS4SDK}/include/c++/v1/" "$ENV{PS4SDK}/include/" "$ENV{PS4SDK}/include/sce/" "$ENV{PS4SDK}/include/ps4/")
+
+cmake_policy(SET CMP0002 NEW)


### PR DESCRIPTION
a quick cmake toolchain file i through together to give users a bit of freedom in controlling their project structure.

cmake can also be read by few IDE, such as Qt, Xcode and Visual Studio as such you'd have access to those IDE directly.
to use
```
cd project; mkdir build; cd build;
cmake -DCMAKE_TOOLCHAIN_FILE=$PS4SDK/cmake/PS4.toolchain.cmake ..
make
```
do note though, my sdk is laid out slightly differently in that I have a `./usr` directory with soft link to `lib` and `include` and have clang built and installed to `./usr/bin`

so i haven't tested this with default clang

edit:
I've made several changes that should allow you to build external cmake projects such as `freetype2` library as a target of your project.

Edit2:
I'm currently maintaining a version of the toolchain on gist https://gist.github.com/Thunder07/fc4688245e4ea9407f42c110ee96070c and will update this PR periodically, but I'm interested if you think this should be included alongside the SDK.